### PR TITLE
Give scheduler schedules distinct logical ids from event bus schedules

### DIFF
--- a/lib/deploy/events/schedule/compileScheduledEvents.js
+++ b/lib/deploy/events/schedule/compileScheduledEvents.js
@@ -121,8 +121,9 @@ module.exports = {
 
             const stateMachineLogicalId = this
               .getStateMachineLogicalId(stateMachineName, stateMachineObj);
-            const scheduleLogicalId = this
-              .getScheduleLogicalId(stateMachineName, scheduleNumberInFunction);
+            const scheduleLogicalId = method !== METHOD_SCHEDULER ? this
+              .getScheduleLogicalId(stateMachineName, scheduleNumberInFunction) : this
+              .getSchedulerScheduleLogicalId(stateMachineName, scheduleNumberInFunction);
             const scheduleIamRoleLogicalId = this
               .getScheduleToStepFunctionsIamRoleLogicalId(stateMachineName);
             const scheduleId = this.getScheduleId(stateMachineName);

--- a/lib/naming.js
+++ b/lib/naming.js
@@ -63,6 +63,12 @@ module.exports = {
       .getNormalizedFunctionName(stateMachineName)}StepFunctionsEventsRuleSchedule${scheduleIndex}`;
   },
 
+  getSchedulerScheduleLogicalId(stateMachineName, scheduleIndex) {
+      return `${this.provider.naming.getNormalizedFunctionName(
+        stateMachineName
+      )}StepFunctionsSchedulerSchedule${scheduleIndex}`;
+  },
+
   getScheduleToStepFunctionsIamRoleLogicalId(stateMachineName) {
     return `${this.provider.naming.getNormalizedFunctionName(
       stateMachineName,


### PR DESCRIPTION
AWS won't let you change the `Type` of a resource, so we need to have distinct logical resource names for scheduler-based schedules to allow a user to update an existing state machine's schedule from an event bus schedule to a scheduler schedule. This will result in removal of the old schedule and creation of the new schedule.